### PR TITLE
feat(peer-discovery): add opt-in YFinanceAdapter for demo peer discovery

### DIFF
--- a/documentation/improve-peer-selection/GET_PEERS_WITH_YFINANCE.md
+++ b/documentation/improve-peer-selection/GET_PEERS_WITH_YFINANCE.md
@@ -1,0 +1,249 @@
+Add optional yfinance-based peer discovery adapter for fast demo peer lists
+
+Goal
+- Provide an optional, pluggable adapter that uses yfinance to produce a believable peer list for a single input ticker. This is intended for demos / proof-of-concept usage: fast, automatable, pragmatic, and easy to tune. It is explicitly not intended to replace the SEC-first canonical peer discovery; that remains the authoritative path for production workflows.
+
+Non-goal
+- Do not replace the SEC-based discovery in the repo. This feature is opt-in and demo-focused only.
+
+Acceptance criteria (all must be satisfied)
+1. Public behavior:
+   - Given a ticker symbol input, a new method returns up to N peers (configurable; default N=10) with at least these fields: ticker, company_name, market_cap (nullable), exchange, source="yfinance".
+2. Efficiency & safety:
+   - Use bulk yfinance queries (yf.Tickers) rather than per-ticker loops.
+3. Caching:
+   - Implement local caching of raw yfinance enrichment payloads with TTL (configurable; default TTL = 24h) under PeerDiscoveryService cache_dir (or under cache_dir/peer_discovery/yfinance).
+4. Rate limiting & backoff:
+   - Enforce a configurable soft rate limit and exponential backoff with max retries (defaults provided). Failures should not crash the pipeline: surface clear errors and fall back to SEC-universe (if available) or return an empty list.
+5. Filtering & heuristics:
+   - Provide a pluggable filter pipeline with these defaults:
+     - Primary match: match on Yahoo industry/sector when available, else best string match on company description keywords or exchange.
+     - Believability default: include peers with market_cap >= max(min_absolute_cap, fraction * target_market_cap), with defaults min_absolute_cap = $50_000_000, fraction = 0.10.
+     - If the target market_cap is missing, fallback to percentile-based selection among candidates.
+     - If filtering yields fewer than min_peers (default 5), progressively relax fraction thresholds (0.10 -> 0.05 -> 0.02).
+   - Deterministic ordering: returned list must be stable across identical inputs (sort by market_cap desc then ticker).
+6. Tests:
+   - Unit tests exist for: bulk fetch + cache hit, missing market_cap handling, filtering behavior, rate-limiting/backoff flow (network mocked), and min_peers relaxation.
+7. Docs:
+   - README updated with configuration options, opt-in instructions, data-source licensing/ToS note, and sample usage.
+8. Opt-in:
+   - The adapter must be disabled by default and enabled via config/env. No implicit behavioral change for existing callers.
+
+Proposed configuration knobs (defaults shown)
+- SIGMAK_PEER_YFINANCE_ENABLED = false
+- SIGMAK_PEER_YFINANCE_N_PEERS = 10
+- SIGMAK_PEER_YFINANCE_MIN_PEERS = 5
+- SIGMAK_PEER_YFINANCE_TTL_SECONDS = 86400  # 24h
+- SIGMAK_PEER_YFINANCE_MIN_FRACTION = 0.10
+- SIGMAK_PEER_YFINANCE_MIN_ABS_CAP = 50_000_000
+- SIGMAK_PEER_YFINANCE_RATE_LIMIT_RPS = 1
+- SIGMAK_PEER_YFINANCE_MAX_RETRIES = 3
+- SIGMAK_PEER_YFINANCE_BACKOFF_BASE_SECONDS = 0.5
+
+High-level implementation plan (step-by-step)
+1. Add adapter module
+   - New file: src/sigmak/adapters/yfinance_adapter.py
+   - Public API:
+     - class YFinanceAdapter(cache_dir: Path, ttl_seconds: int, rate_limit_rps: float, max_retries: int, backoff_base: float)
+     - method fetch_bulk(tickers: List[str]) -> Dict[str, Dict]  # normalized metadata per ticker (includes None for missing fields)
+   - Responsibilities:
+     - Use yf.Tickers for bulk requests.
+     - Cache raw payloads to JSON files under cache_dir/peer_discovery/yfinance/{hash_of_sorted_tickers}.json with timestamp.
+     - Normalize fields: ticker, shortName/companyName, marketCap (int or None), exchange, industry/sector, raw_source (timestamp, raw payload).
+     - Respect rate limit and implement exponential backoff for transient failures (with retries).
+     - Provide telemetry/logging on cache hit/miss, retries, and errors.
+
+2. Add PeerDiscoveryService wrapper method (opt-in)
+   - Modify src/sigmak/peer_discovery.py to add (non-breaking) method:
+     - get_peers_via_yfinance(ticker: str, n: int = None, config: Optional[dict] = None) -> List[PeerRecord]
+   - Behavior:
+     - If env/config SIGMAK_PEER_YFINANCE_ENABLED is false: raise a clear NotEnabled error or return None/empty (prefer returning empty and logging).
+     - Use existing PeerDiscoveryService.cache_dir and user_agent for cache location and polite logging.
+     - Steps:
+       1. Fetch target ticker metadata via yfinance adapter (single bulk call can include target).
+       2. Build candidate universe via adapter heuristics: e.g., industry top companies if yfinance exposes, or search for related tickers (adapter returns top companies or top N tickers in industry when available).
+       3. Enrich candidate universe via fetch_bulk.
+       4. Apply believability filter pipeline described above.
+       5. Return up to N peers with canonical fields and source="yfinance".
+
+3. Tests (TDD-first)
+   - New tests: tests/test_peer_discovery_yfinance.py
+   - Use mocking (pytest + monkeypatch) for yfinance objects and for the filesystem cache. Alternatively use lightweight VCR fixtures for one integration-style test.
+   - Test cases to include:
+     - test_bulk_fetch_uses_single_yf_call_and_cache: assert adapter calls yf.Tickers once for multiple tickers and next call reads from cache.
+     - test_filter_by_marketcap_and_fraction: given sample marketCaps, assert correct filtering sets.
+     - test_missing_target_marketcap_percentile_fallback: if target market cap is None, ensure selection by percentile works.
+     - test_min_peers_relaxation_progresses_correctly: if too few peers, thresholds relax deterministically.
+     - test_backoff_and_retries_on_transient_errors: simulate transient failures and assert retries and fallback.
+   - Keep tests deterministic and fast by mocking yfinance and time.sleep backoff.
+
+4. Docs and UX
+   - Update README.md section "Peer discovery" with:
+     - Explanation of opt-in yfinance adapter, defaults, and configuration.
+     - Example CLI/env to enable it.
+     - ToS/legal note: explain yfinance is an unofficial Yahoo wrapper; consult Yahoo terms and make feature opt-in for client demos.
+   - Add a JOURNAL.md entry describing why this demo path exists and tradeoffs.
+   - Add whether the adapter is allowed to log raw yfinance payloads and where (sensitive info consideration).
+
+5. CI
+   - Ensure new tests run under CI and do not perform real network calls (mocking required).
+   - Add any test fixtures to tests/fixtures and keep them small.
+
+Files to add/modify (suggested)
+- Add: src/sigmak/adapters/yfinance_adapter.py
+- Modify: src/sigmak/peer_discovery.py (add wrapper method only; keep existing code unchanged otherwise)
+- Add: tests/test_peer_discovery_yfinance.py
+- Modify: README.md (Peer discovery section)
+- Modify or add: JOURNAL.md (note about feature and tradeoffs)
+- Add: .github/labels or project/meta as appropriate (optional)
+
+Sample output (one example JSON object per peer)
+[
+  {
+    "ticker": "APH",
+    "company_name": "Amphenol Corporation",
+    "market_cap": 35000000000,
+    "exchange": "NYSE",
+    "industry": "Electrical Products",
+    "source": "yfinance",
+    "enriched_at": "2026-02-20T12:34:56Z"
+  },
+  {
+    "ticker": "TE",
+    "company_name": "TE Connectivity Ltd.",
+    "market_cap": 27000000000,
+    "exchange": "NYSE",
+    "industry": "Electrical Products",
+    "source": "yfinance",
+    "enriched_at": "2026-02-20T12:34:56Z"
+  }
+]
+
+Security & compliance notes
+- yfinance uses unofficial Yahoo endpoints. Document ToS implications in README and make the feature opt-in. Avoid recommending heavy, sustained scraping in client demos.
+- Use a clear User-Agent on any HTTP wrappers (PeerDiscoveryService already uses user_agent for SEC calls; apply same pattern).
+- Do not commit raw cached payloads to the repo.
+
+Suggested tests / QA checklist (for you while developing locally)
+- Unit tests pass with mocks only (no network).
+- Integration test with one recorded fixture (VCR) that demonstrates end-to-end enrichment and filtering.
+- Manual demo: enable adapter locally, run get_peers_via_yfinance for a few tickers, verify performance and believable output.
+- Observe cache TTL behavior by altering system clock or TTL and asserting refresh occurs.
+
+Suggested labels / assignees / milestone
+- labels: enhancement, feature/demo, needs-tests, opt-in
+- assignee: (leave blank or add yourself)
+- milestone: v0.1-demo or similar
+
+Questions / configuration items for you to decide (answer in comments on the Issue)
+1. Default N peers for demos (I propose N=10; min_peers=5).
+2. Should the adapter be disabled by default? (I recommend disabled by default; opt-in.)
+3. Preferred cache location: default to existing PeerDiscoveryService.cache_dir/peer_discovery/yfinance? (recommended: yes)
+4. Any legal constraint about mentioning Yahoo publicly in client-facing demo docs?
+
+Checklist for the Issue body (to paste at the bottom of the Issue)
+- [ ] Create adapter file src/sigmak/adapters/yfinance_adapter.py
+- [ ] Add PeerDiscoveryService.get_peers_via_yfinance wrapper method
+- [ ] Implement caching per TTL in cache_dir
+- [ ] Implement rate-limiting and exponential backoff
+- [ ] Implement believability filter pipeline and deterministic ordering
+- [ ] Add unit tests and fixtures in tests/test_peer_discovery_yfinance.py
+- [ ] Add README.md docs + JOURNAL.md entry
+- [ ] Ensure CI runs tests with mocks (no external network)
+- [ ] Manual demo verification and cache TTL test
+
+---
+
+If you want, I can also:
+- Produce a compact checklist-only Issue body (shorter) for quick pasting.
+- Draft the exact README paragraph and the minimal test skeleton (no production code) you can paste into your local environment to begin TDD.
+
+---
+<!-- AGENT_IMPLEMENTATION_PLAN_START -->
+## Implementation Plan (ready to execute — do not edit this section manually)
+
+> **Status**: APPROVED, NOT YET STARTED  
+> **Agreed**: 2026-02-20  
+> **Run tests with**: `uv run pytest`
+
+### Locked-in decisions
+
+| # | Decision |
+|---|---|
+| Candidate pool | `yf.Ticker(target).info["industryKey"]` → `yf.Industry(key)` probed defensively for top-companies list |
+| DB write | Upsert `market_cap`, `exchange`, `industry` back into existing `peers` table via `upsert_peer()` as a side-effect |
+| `PeerRecord` | `@dataclass` (fields: `ticker`, `company_name`, `market_cap: Optional[int]`, `exchange`, `industry`, `sector`, `source`, `enriched_at`) |
+| Tests | All mocked with `monkeypatch`; no VCR, no real network |
+| `yf.Industry` probe | Defensive: try `.top_companies` (DataFrame index), then `.tickers`, then `.members`; log which succeeded; gracefully return `[]` on total failure |
+
+### Files to create / modify
+
+| Action | File |
+|---|---|
+| CREATE | `src/sigmak/adapters/__init__.py` (empty package marker) |
+| CREATE | `src/sigmak/adapters/yfinance_adapter.py` (adapter + `PeerRecord`) |
+| MODIFY | `src/sigmak/peer_discovery.py` (add `get_peers_via_yfinance` wrapper method only; no other changes) |
+| CREATE | `tests/test_peer_discovery_yfinance.py` (TDD-first, all mocked) |
+| MODIFY | `README.md` (add yfinance adapter section) |
+| MODIFY | `JOURNAL.md` (add feature entry) |
+
+### Implementation steps (ordered)
+
+1. **Create adapter package** — `src/sigmak/adapters/__init__.py` (empty)
+
+2. **Write tests first** — `tests/test_peer_discovery_yfinance.py`:
+   - `test_bulk_fetch_uses_single_yf_tickers_call_and_caches`
+   - `test_filter_by_marketcap_and_fraction`
+   - `test_missing_target_marketcap_percentile_fallback`
+   - `test_min_peers_relaxation_progresses_correctly`
+   - `test_backoff_and_retries_on_transient_errors`
+   - `test_industry_object_probed_defensively`
+   - `test_adapter_disabled_by_default`
+
+3. **Implement `PeerRecord` dataclass and `YFinanceAdapter` class** — `src/sigmak/adapters/yfinance_adapter.py`:
+   - `__init__(cache_dir, ttl_seconds, rate_limit_rps, max_retries, backoff_base)` — reads env vars for defaults
+   - `_resolve_industry_key(ticker) -> Optional[str]`
+   - `_get_industry_candidates(industry_key) -> List[str]` — defensive probe of `yf.Industry`
+   - `fetch_bulk(tickers) -> Dict[str, Dict]` — `yf.Tickers`, normalize, cache to `cache_dir/yfinance/{hash}.json` with TTL
+   - `_apply_filter_pipeline(candidates, target_market_cap) -> List[PeerRecord]` — fraction filter 0.10→0.05→0.02 relaxation; sort by `market_cap DESC NULLS LAST, ticker ASC`
+   - `get_peers(ticker, n) -> List[PeerRecord]` — orchestrates above + calls `upsert_peer()` for each result
+
+4. **Add wrapper to `PeerDiscoveryService`** — `src/sigmak/peer_discovery.py`:
+   - `get_peers_via_yfinance(ticker: str, n: Optional[int] = None) -> List` 
+   - Guards on `SIGMAK_PEER_YFINANCE_ENABLED`; instantiates `YFinanceAdapter` using `self.cache_dir` and `self.db_path`
+
+5. **Update `README.md`** — "Peer discovery: yfinance adapter" section with opt-in config, knobs table, ToS note, sample snippet
+
+6. **Update `JOURNAL.md`** — one entry for the feature and tradeoff rationale
+
+### Config knobs (env vars)
+
+```
+SIGMAK_PEER_YFINANCE_ENABLED        = false      # must be set to "true" to enable
+SIGMAK_PEER_YFINANCE_N_PEERS        = 10
+SIGMAK_PEER_YFINANCE_MIN_PEERS      = 5
+SIGMAK_PEER_YFINANCE_TTL_SECONDS    = 86400      # 24h
+SIGMAK_PEER_YFINANCE_MIN_FRACTION   = 0.10
+SIGMAK_PEER_YFINANCE_MIN_ABS_CAP    = 50000000
+SIGMAK_PEER_YFINANCE_RATE_LIMIT_RPS = 1
+SIGMAK_PEER_YFINANCE_MAX_RETRIES    = 3
+SIGMAK_PEER_YFINANCE_BACKOFF_BASE   = 0.5
+```
+
+### Verification commands
+
+```bash
+# All unit tests pass with no network calls
+uv run pytest tests/test_peer_discovery_yfinance.py -v
+
+# Manual smoke-test (opt-in enabled)
+SIGMAK_PEER_YFINANCE_ENABLED=true uv run python -c "
+from sigmak.peer_discovery import PeerDiscoveryService
+svc = PeerDiscoveryService()
+print(svc.get_peers_via_yfinance('MSFT', n=5))
+"
+
+# Confirm upsert side-effect
+sqlite3 database/sec_filings.db "SELECT ticker, market_cap, industry FROM peers LIMIT 10;"
+```
+<!-- AGENT_IMPLEMENTATION_PLAN_END -->

--- a/src/sigmak/adapters/__init__.py
+++ b/src/sigmak/adapters/__init__.py
@@ -1,0 +1,1 @@
+# Adapter modules for optional, pluggable data sources.

--- a/src/sigmak/adapters/yfinance_adapter.py
+++ b/src/sigmak/adapters/yfinance_adapter.py
@@ -1,0 +1,414 @@
+"""
+Optional yfinance-based peer discovery adapter.
+
+This adapter is OPT-IN only (disabled by default).
+Enable via: SIGMAK_PEER_YFINANCE_ENABLED=true
+
+Design:
+- PeerRecord   : lightweight @dataclass for a single enriched peer
+- YFinanceAdapter : fetches, caches, filters, and ranks peer candidates
+  1. Resolve target ticker's industryKey via yf.Ticker(target).info
+  2. Probe yf.Industry(industryKey) defensively for a top-company list
+  3. Bulk-enrich candidates with yf.Tickers
+  4. Apply market-cap believability filter with progressive relaxation
+  5. Upsert enriched peers into the filings DB as a side-effect
+  6. Return List[PeerRecord] sorted by market_cap DESC, ticker ASC
+
+NOTE: yfinance wraps unofficial Yahoo Finance endpoints. This feature is
+intentionally opt-in for demo/PoC usage. Consult Yahoo's Terms of Service
+before using in sustained production workflows.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time as time  # aliased so tests can patch 'sigmak.adapters.yfinance_adapter.time'
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    import yfinance as yf  # noqa: F401
+    import pandas as pd    # noqa: F401
+except ImportError:  # pragma: no cover
+    yf = None
+    pd = None
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Public data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PeerRecord:
+    """Enriched peer metadata returned by YFinanceAdapter.get_peers()."""
+
+    ticker: str
+    company_name: Optional[str]
+    market_cap: Optional[int]
+    exchange: Optional[str]
+    industry: Optional[str]
+    sector: Optional[str]
+    source: str
+    enriched_at: str  # ISO-8601 UTC
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+class YFinanceAdapter:
+    """
+    Fetch, cache, and rank peer candidates using yfinance.
+
+    Parameters
+    ----------
+    cache_dir        : Base cache directory. Payloads written to cache_dir/yfinance/
+    ttl_seconds      : Cache time-to-live in seconds (default 24 h).
+    rate_limit_rps   : Soft rate limit (requests per second) — currently applied
+                       as a minimum sleep between retries only (yf.Tickers is one
+                       bulk request regardless of ticker count).
+    max_retries      : Number of attempts for transient network errors.
+    backoff_base     : Base seconds for exponential backoff between retries.
+    min_peers        : Minimum peers to return; triggers threshold relaxation.
+    min_fraction     : Initial market-cap fraction threshold (default 0.10).
+    min_abs_cap      : Absolute minimum market_cap floor in USD (default $50 M).
+    n_peers          : Maximum peers to return (default 10).
+    """
+
+    _FRACTION_STEPS: List[float] = [0.10, 0.05, 0.02, 0.0]
+
+    def __init__(
+        self,
+        cache_dir: Path,
+        ttl_seconds: int = 86400,
+        rate_limit_rps: float = 1.0,
+        max_retries: int = 3,
+        backoff_base: float = 0.5,
+        min_peers: int = 5,
+        min_fraction: float = 0.10,
+        min_abs_cap: int = 50_000_000,
+        n_peers: int = 10,
+    ) -> None:
+        self.cache_dir = Path(cache_dir) / "yfinance"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.ttl_seconds = ttl_seconds
+        self.rate_limit_rps = rate_limit_rps
+        self.max_retries = max_retries
+        self.backoff_base = backoff_base
+        self.min_peers = min_peers
+        self.min_fraction = min_fraction
+        self.min_abs_cap = min_abs_cap
+        self.n_peers = n_peers
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_peers(self, ticker: str, n: Optional[int] = None, db_path: Optional[str] = None) -> List[PeerRecord]:
+        """
+        Main entry point: return up to n enriched PeerRecords for ticker.
+
+        Side-effect: upserts market_cap / exchange / industry back into
+        the filings DB (peers table) via upsert_peer().
+        """
+        n = n or self.n_peers
+        ticker = ticker.upper()
+
+        # 1. Resolve industry key for target
+        industry_key = self._resolve_industry_key(ticker)
+        if not industry_key:
+            logger.warning("yfinance: could not resolve industryKey for %s", ticker)
+            return []
+
+        # 2. Get candidate tickers from industry object
+        candidate_tickers = self._get_industry_candidates(industry_key)
+        # Always include the target itself for enrichment (skip it in output)
+        all_tickers = list({ticker} | set(candidate_tickers))
+
+        if not all_tickers:
+            logger.warning("yfinance: no candidate tickers found for industry %s", industry_key)
+            return []
+
+        # 3. Bulk-enrich
+        enriched = self.fetch_bulk(all_tickers)
+
+        target_data = enriched.get(ticker, {})
+        target_market_cap: Optional[int] = target_data.get("market_cap")
+
+        # Exclude target from peer candidates
+        candidates = {t: d for t, d in enriched.items() if t != ticker}
+
+        # 4. Apply filter + sort
+        peers = self._apply_filter_pipeline(candidates, target_market_cap)[:n]
+
+        # 5. Upsert back into DB (best-effort)
+        if db_path:
+            self._upsert_peers_to_db(peers, db_path)
+
+        return peers
+
+    # ------------------------------------------------------------------
+    # Industry candidate discovery
+    # ------------------------------------------------------------------
+
+    def _resolve_industry_key(self, ticker: str) -> Optional[str]:
+        """Get Yahoo industryKey for a ticker via yf.Ticker.info."""
+        if yf is None:  # pragma: no cover
+            logger.error("yfinance not installed")
+            return None
+        try:
+            info = yf.Ticker(ticker).info
+            raw: Any = info.get("industryKey") or info.get("industry")
+            return str(raw) if raw is not None else None
+        except Exception as exc:
+            logger.warning("yfinance: failed to resolve industryKey for %s: %s", ticker, exc)
+            return None
+
+    def _get_industry_candidates(self, industry_key: str) -> List[str]:
+        """
+        Probe yf.Industry(industry_key) defensively for member tickers.
+
+        Tries in order:
+          1. .top_companies  (DataFrame — use index as tickers)
+          2. .tickers        (list or dict)
+          3. .members        (list or dict)
+
+        Returns [] if none succeed.
+        """
+        if yf is None:  # pragma: no cover
+            return []
+        try:
+            industry_obj = yf.Industry(industry_key)
+        except Exception as exc:
+            logger.warning("yfinance: yf.Industry(%s) raised: %s", industry_key, exc)
+            return []
+
+        # --- try top_companies (DataFrame) ---
+        top = getattr(industry_obj, "top_companies", None)
+        if top is not None:
+            try:
+                if pd is not None and isinstance(top, pd.DataFrame):
+                    tickers = [str(t).upper() for t in top.index.tolist()]
+                    logger.debug("yfinance: industry %s → top_companies → %d tickers", industry_key, len(tickers))
+                    return tickers
+            except Exception as exc:
+                logger.debug("yfinance: top_companies probe failed: %s", exc)
+
+        # --- try .tickers ---
+        tickers_attr = getattr(industry_obj, "tickers", None)
+        if tickers_attr is not None:
+            try:
+                if isinstance(tickers_attr, dict):
+                    tickers = [str(t).upper() for t in tickers_attr.keys()]
+                else:
+                    tickers = [str(t).upper() for t in tickers_attr]
+                logger.debug("yfinance: industry %s → .tickers → %d tickers", industry_key, len(tickers))
+                return tickers
+            except Exception as exc:
+                logger.debug("yfinance: .tickers probe failed: %s", exc)
+
+        # --- try .members ---
+        members_attr = getattr(industry_obj, "members", None)
+        if members_attr is not None:
+            try:
+                if isinstance(members_attr, dict):
+                    tickers = [str(t).upper() for t in members_attr.keys()]
+                else:
+                    tickers = [str(t).upper() for t in members_attr]
+                logger.debug("yfinance: industry %s → .members → %d tickers", industry_key, len(tickers))
+                return tickers
+            except Exception as exc:
+                logger.debug("yfinance: .members probe failed: %s", exc)
+
+        logger.warning(
+            "yfinance: yf.Industry(%s) has no usable top_companies/tickers/members attribute. "
+            "Returning empty candidate list.",
+            industry_key,
+        )
+        return []
+
+    # ------------------------------------------------------------------
+    # Bulk enrichment with caching
+    # ------------------------------------------------------------------
+
+    def _cache_key(self, tickers: List[str]) -> str:
+        joined = ",".join(sorted(t.upper() for t in tickers))
+        return hashlib.md5(joined.encode()).hexdigest()
+
+    def _cache_path(self, tickers: List[str]) -> Path:
+        return self.cache_dir / f"{self._cache_key(tickers)}.json"
+
+    def _is_cache_valid(self, path: Path) -> bool:
+        if not path.exists():
+            return False
+        age = time.time() - path.stat().st_mtime
+        return age < self.ttl_seconds
+
+    def fetch_bulk(self, tickers: List[str]) -> Dict[str, Dict[str, Any]]:
+        """
+        Fetch yfinance metadata for a list of tickers.
+
+        - Returns from disk cache if TTL has not elapsed.
+        - Uses yf.Tickers (single bulk request) for all tickers.
+        - Retries up to max_retries on transient errors with exponential backoff.
+        - Returns {} if all retries fail.
+        """
+        if not tickers:
+            return {}
+
+        cache_file = self._cache_path(tickers)
+
+        # Cache hit
+        if self._is_cache_valid(cache_file):
+            logger.debug("yfinance: cache hit for %d tickers → %s", len(tickers), cache_file)
+            try:
+                cached: Dict[str, Dict[str, Any]] = json.loads(cache_file.read_text(encoding="utf-8"))
+                return cached
+            except Exception as exc:
+                logger.warning("yfinance: corrupt cache %s: %s — refetching", cache_file, exc)
+
+        # Cache miss → fetch with retries
+        joined = " ".join(t.upper() for t in tickers)
+        raw_data: Dict[str, Any] = {}
+
+        for attempt in range(self.max_retries):
+            try:
+                if yf is None:  # pragma: no cover
+                    raise RuntimeError("yfinance not installed")
+                tickers_obj = yf.Tickers(joined)
+                raw_data = tickers_obj.tickers
+                logger.info("yfinance: fetched %d tickers (attempt %d)", len(tickers), attempt + 1)
+                break
+            except Exception as exc:
+                logger.warning("yfinance: fetch attempt %d/%d failed: %s", attempt + 1, self.max_retries, exc)
+                if attempt < self.max_retries - 1:
+                    sleep_secs = self.backoff_base * (2 ** attempt)
+                    time.sleep(sleep_secs)
+        else:
+            logger.error("yfinance: all %d retries exhausted — returning {}", self.max_retries)
+            return {}
+
+        # Normalize
+        enriched_at = datetime.now(timezone.utc).isoformat()
+        normalized: Dict[str, Dict[str, Any]] = {}
+        for t, ticker_obj in raw_data.items():
+            t_up = t.upper()
+            try:
+                info: Dict[str, Any] = ticker_obj.info or {}
+            except Exception:
+                info = {}
+            normalized[t_up] = {
+                "ticker": t_up,
+                "company_name": info.get("shortName") or info.get("longName") or info.get("companyName"),
+                "market_cap": info.get("marketCap"),
+                "exchange": info.get("exchange"),
+                "industry": info.get("industry"),
+                "sector": info.get("sector"),
+                "industry_key": info.get("industryKey"),
+                "sector_key": info.get("sectorKey"),
+                "enriched_at": enriched_at,
+            }
+
+        # Write cache
+        try:
+            cache_file.write_text(json.dumps(normalized, default=str), encoding="utf-8")
+            logger.debug("yfinance: wrote cache %s", cache_file)
+        except Exception as exc:
+            logger.warning("yfinance: could not write cache: %s", exc)
+
+        return normalized
+
+    # ------------------------------------------------------------------
+    # Filter pipeline
+    # ------------------------------------------------------------------
+
+    def _apply_filter_pipeline(
+        self,
+        candidates: Dict[str, Dict[str, Any]],
+        target_market_cap: Optional[int],
+    ) -> List[PeerRecord]:
+        """
+        Apply believability filter with progressive relaxation.
+
+        If target_market_cap is known:
+          threshold = max(min_abs_cap, fraction * target_market_cap)
+          Steps: 0.10 → 0.05 → 0.02 → 0.0 (include all with market_cap)
+
+        If target_market_cap is None:
+          Select peers in the top 50th percentile by market_cap.
+        """
+        enriched_at = datetime.now(timezone.utc).isoformat()
+
+        def to_record(d: Dict[str, Any]) -> PeerRecord:
+            return PeerRecord(
+                ticker=d["ticker"].upper(),
+                company_name=d.get("company_name"),
+                market_cap=d.get("market_cap"),
+                exchange=d.get("exchange"),
+                industry=d.get("industry"),
+                sector=d.get("sector"),
+                source="yfinance",
+                enriched_at=d.get("enriched_at") or enriched_at,
+            )
+
+        if target_market_cap is None:
+            # Percentile fallback: top 50th percentile by market_cap
+            with_cap = [(t, d) for t, d in candidates.items() if d.get("market_cap") is not None]
+            if not with_cap:
+                # Return all sorted by ticker if nothing has a cap
+                return sorted([to_record(d) for d in candidates.values()], key=lambda p: p.ticker)
+            caps = sorted([d["market_cap"] for _, d in with_cap], reverse=True)
+            median_cap = caps[len(caps) // 2]
+            filtered = [d for _, d in with_cap if d["market_cap"] >= median_cap]
+            return self._sort_records([to_record(d) for d in filtered])
+
+        # Known target market_cap — progressive threshold relaxation
+        for fraction in self._FRACTION_STEPS:
+            threshold = max(self.min_abs_cap, fraction * target_market_cap)
+            filtered = [
+                d for d in candidates.values()
+                if d.get("market_cap") is not None and d["market_cap"] >= threshold
+            ]
+            if len(filtered) >= self.min_peers or fraction == 0.0:
+                return self._sort_records([to_record(d) for d in filtered])
+
+        return []
+
+    @staticmethod
+    def _sort_records(records: List[PeerRecord]) -> List[PeerRecord]:
+        """Sort by market_cap DESC (NULLs last), then ticker ASC for stability."""
+        return sorted(
+            records,
+            key=lambda p: (-(p.market_cap or 0), p.ticker),
+        )
+
+    # ------------------------------------------------------------------
+    # DB side-effect
+    # ------------------------------------------------------------------
+
+    def _upsert_peers_to_db(self, peers: List[PeerRecord], db_path: str) -> None:
+        """Write enriched market_cap / exchange / industry back into the peers table."""
+        try:
+            from sigmak.filings_db import upsert_peer
+        except ImportError:  # pragma: no cover
+            logger.warning("yfinance: sigmak.filings_db not available; skipping DB upsert")
+            return
+
+        for peer in peers:
+            try:
+                upsert_peer(
+                    db_path,
+                    peer.ticker,
+                    cik=None,
+                    sic=None,
+                    industry=peer.industry,
+                    market_cap=float(peer.market_cap) if peer.market_cap is not None else None,
+                )
+            except Exception as exc:
+                logger.warning("yfinance: upsert_peer failed for %s: %s", peer.ticker, exc)

--- a/tests/test_peer_discovery_yfinance.py
+++ b/tests/test_peer_discovery_yfinance.py
@@ -1,0 +1,310 @@
+"""
+TDD tests for the yfinance peer discovery adapter.
+
+Issue: GET_PEERS_WITH_YFINANCE (see documentation/improve-peer-selection/)
+
+All tests are fully mocked — no real network calls.
+Run with: uv run pytest tests/test_peer_discovery_yfinance.py -v
+"""
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from sigmak.adapters.yfinance_adapter import PeerRecord, YFinanceAdapter
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_adapter(tmp_path: Path, **kwargs: Any) -> YFinanceAdapter:
+    """Return a YFinanceAdapter backed by a temp directory."""
+    defaults = dict(
+        cache_dir=tmp_path,
+        ttl_seconds=86400,
+        rate_limit_rps=100.0,  # no throttle in tests
+        max_retries=3,
+        backoff_base=0.0,      # no sleep in tests
+    )
+    defaults.update(kwargs)
+    return YFinanceAdapter(**defaults)
+
+
+def _ticker_info(
+    ticker: str,
+    market_cap: int | None = 1_000_000_000,
+    industry: str = "Software",
+    sector: str = "Technology",
+    exchange: str = "NMS",
+    short_name: str | None = None,
+) -> Dict[str, Any]:
+    return {
+        "symbol": ticker,
+        "shortName": short_name or f"{ticker} Corp",
+        "marketCap": market_cap,
+        "exchange": exchange,
+        "industry": industry,
+        "sector": sector,
+        "industryKey": industry.lower().replace(" ", "-"),
+        "sectorKey": sector.lower().replace(" ", "-"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — bulk fetch calls yf.Tickers once and writes cache
+# ---------------------------------------------------------------------------
+
+def test_bulk_fetch_uses_single_yf_tickers_call_and_caches(tmp_path: Path) -> None:
+    """
+    SRP: Adapter must call yf.Tickers exactly once for a ticker list,
+    normalise the result, and write a JSON cache file.
+    """
+    adapter = _make_adapter(tmp_path)
+
+    mock_tickers_obj = MagicMock()
+    mock_tickers_obj.tickers = {
+        "AAPL": MagicMock(info=_ticker_info("AAPL", market_cap=3_000_000_000_000)),
+        "MSFT": MagicMock(info=_ticker_info("MSFT", market_cap=2_500_000_000_000)),
+    }
+
+    with patch("sigmak.adapters.yfinance_adapter.yf") as mock_yf:
+        mock_yf.Tickers.return_value = mock_tickers_obj
+        result = adapter.fetch_bulk(["AAPL", "MSFT"])
+
+    # yf.Tickers must be called exactly once
+    mock_yf.Tickers.assert_called_once()
+
+    assert "AAPL" in result
+    assert "MSFT" in result
+    assert result["AAPL"]["market_cap"] == 3_000_000_000_000
+    assert result["MSFT"]["ticker"] == "MSFT"
+
+    # Cache file should exist
+    cache_files = list(tmp_path.glob("yfinance/*.json"))
+    assert len(cache_files) == 1
+
+
+def test_bulk_fetch_cache_hit_skips_network_call(tmp_path: Path) -> None:
+    """
+    SRP: A second call with the same tickers must read from cache,
+    not call yf.Tickers again.
+    """
+    adapter = _make_adapter(tmp_path)
+
+    mock_tickers_obj = MagicMock()
+    mock_tickers_obj.tickers = {
+        "AAPL": MagicMock(info=_ticker_info("AAPL")),
+    }
+
+    with patch("sigmak.adapters.yfinance_adapter.yf") as mock_yf:
+        mock_yf.Tickers.return_value = mock_tickers_obj
+        adapter.fetch_bulk(["AAPL"])  # first call — hits network
+        adapter.fetch_bulk(["AAPL"])  # second call — should hit cache
+
+    # Network should only have been hit once
+    assert mock_yf.Tickers.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — market-cap fraction filter
+# ---------------------------------------------------------------------------
+
+def test_filter_by_marketcap_and_fraction(tmp_path: Path) -> None:
+    """
+    SRP: confirm peers with market_cap >= max(min_abs, fraction * target) are kept.
+    Default fraction=0.10, min_abs=50_000_000.
+    Target market_cap = 1_000_000_000 → threshold = 100_000_000.
+    """
+    adapter = _make_adapter(tmp_path)
+
+    candidates = {
+        "BIG":  {"ticker": "BIG",  "market_cap": 500_000_000, "company_name": "Big Co",  "exchange": "NYSE", "industry": "Software", "sector": "Technology"},
+        "MID":  {"ticker": "MID",  "market_cap": 100_000_000, "company_name": "Mid Co",  "exchange": "NYSE", "industry": "Software", "sector": "Technology"},
+        "TINY": {"ticker": "TINY", "market_cap":  10_000_000, "company_name": "Tiny Co", "exchange": "NYSE", "industry": "Software", "sector": "Technology"},
+        "NONE": {"ticker": "NONE", "market_cap": None,        "company_name": "None Co", "exchange": "NYSE", "industry": "Software", "sector": "Technology"},
+    }
+
+    result = adapter._apply_filter_pipeline(candidates, target_market_cap=1_000_000_000)
+
+    tickers = [p.ticker for p in result]
+    assert "BIG" in tickers
+    assert "MID" in tickers   # exactly at threshold — included
+    assert "TINY" not in tickers
+    # None market_cap excluded when target is known
+    assert "NONE" not in tickers
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — missing target market_cap -> percentile fallback
+# ---------------------------------------------------------------------------
+
+def test_missing_target_marketcap_percentile_fallback(tmp_path: Path) -> None:
+    """
+    SRP: When target market_cap is None, select peers by top-50th-percentile
+    among candidates rather than crashing or returning nothing.
+    """
+    adapter = _make_adapter(tmp_path)
+
+    candidates = {
+        t: {"ticker": t, "market_cap": mc, "company_name": f"{t} Co",
+            "exchange": "NYSE", "industry": "Software", "sector": "Technology"}
+        for t, mc in [("A", 900_000_000), ("B", 700_000_000),
+                      ("C", 500_000_000), ("D", 300_000_000),
+                      ("E", 100_000_000)]
+    }
+
+    result = adapter._apply_filter_pipeline(candidates, target_market_cap=None)
+
+    # Must return something (top half = A, B, C)
+    assert len(result) >= 1
+    tickers = [p.ticker for p in result]
+    # Largest should always be included
+    assert "A" in tickers
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — min_peers relaxation
+# ---------------------------------------------------------------------------
+
+def test_min_peers_relaxation_progresses_correctly(tmp_path: Path) -> None:
+    """
+    SRP: If filtering at fraction=0.10 yields fewer than min_peers,
+    the adapter relaxes to 0.05 then 0.02 until min_peers is met or exhausted.
+    """
+    adapter = _make_adapter(tmp_path, min_peers=3)
+
+    # Only 2 candidates pass 0.10 threshold (target=10B → threshold=1B)
+    # All 4 pass 0.02 threshold (threshold=200M)
+    candidates = {
+        t: {"ticker": t, "market_cap": mc, "company_name": f"{t} Co",
+            "exchange": "NYSE", "industry": "Software", "sector": "Technology"}
+        for t, mc in [
+            ("A", 5_000_000_000),
+            ("B", 2_000_000_000),
+            ("C",   500_000_000),
+            ("D",   300_000_000),
+        ]
+    }
+
+    result = adapter._apply_filter_pipeline(candidates, target_market_cap=10_000_000_000)
+
+    # With relaxation, should include at least min_peers (3)
+    assert len(result) >= 3
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — backoff + retries on transient errors
+# ---------------------------------------------------------------------------
+
+def test_backoff_and_retries_on_transient_errors(tmp_path: Path) -> None:
+    """
+    SRP: When yf.Tickers raises a transient error, the adapter retries
+    up to max_retries times before giving up and returning {}.
+    """
+    adapter = _make_adapter(tmp_path, max_retries=3, backoff_base=0.0)
+
+    with patch("sigmak.adapters.yfinance_adapter.yf") as mock_yf, \
+         patch("sigmak.adapters.yfinance_adapter.time") as mock_time:
+        mock_yf.Tickers.side_effect = ConnectionError("network blip")
+        mock_time.sleep = MagicMock()
+        result = adapter.fetch_bulk(["AAPL"])
+
+    # Should have retried max_retries times
+    assert mock_yf.Tickers.call_count == adapter.max_retries
+    # Should return empty dict (not crash)
+    assert result == {}
+    # Should have slept between retries (backoff_base=0 → sleep(0) still called)
+    assert mock_time.sleep.call_count == adapter.max_retries - 1
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — yf.Industry probed defensively
+# ---------------------------------------------------------------------------
+
+def test_industry_object_probed_defensively(tmp_path: Path) -> None:
+    """
+    SRP: _get_industry_candidates() must try top_companies, then tickers, then
+    members. If none exist, return [] without raising.
+    """
+    adapter = _make_adapter(tmp_path)
+
+    # Object with none of the expected attributes
+    bare_mock = MagicMock(spec=[])  # spec=[] means no attributes
+
+    with patch("sigmak.adapters.yfinance_adapter.yf") as mock_yf:
+        mock_yf.Industry.return_value = bare_mock
+        result = adapter._get_industry_candidates("software-application")
+
+    assert result == []
+
+
+def test_industry_object_top_companies_dataframe(tmp_path: Path) -> None:
+    """
+    SRP: When yf.Industry has .top_companies (a DataFrame), use its index as tickers.
+    """
+    import pandas as pd
+
+    adapter = _make_adapter(tmp_path)
+
+    mock_industry = MagicMock()
+    mock_industry.top_companies = pd.DataFrame(
+        {"name": ["Apple Inc", "Microsoft Corp"]},
+        index=["AAPL", "MSFT"]
+    )
+
+    with patch("sigmak.adapters.yfinance_adapter.yf") as mock_yf:
+        mock_yf.Industry.return_value = mock_industry
+        result = adapter._get_industry_candidates("software-application")
+
+    assert "AAPL" in result
+    assert "MSFT" in result
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — adapter disabled by default / env guard
+# ---------------------------------------------------------------------------
+
+def test_adapter_disabled_returns_empty_list(tmp_path: Path) -> None:
+    """
+    SRP: get_peers_via_yfinance on PeerDiscoveryService returns [] and does
+    not call the adapter when SIGMAK_PEER_YFINANCE_ENABLED is not 'true'.
+    """
+    from sigmak.peer_discovery import PeerDiscoveryService
+
+    svc = PeerDiscoveryService(cache_dir=tmp_path)
+
+    with patch.dict("os.environ", {"SIGMAK_PEER_YFINANCE_ENABLED": "false"}):
+        with patch("sigmak.adapters.yfinance_adapter.yf") as mock_yf:
+            result = svc.get_peers_via_yfinance("MSFT", n=5)
+
+    assert result == []
+    mock_yf.Tickers.assert_not_called()
+
+
+def test_adapter_enabled_calls_get_peers(tmp_path: Path) -> None:
+    """
+    SRP: When SIGMAK_PEER_YFINANCE_ENABLED=true, get_peers_via_yfinance
+    delegates to YFinanceAdapter.get_peers() and returns the result.
+    """
+    from sigmak.peer_discovery import PeerDiscoveryService
+
+    expected = [PeerRecord(
+        ticker="MSFT", company_name="Microsoft Corp",
+        market_cap=2_500_000_000_000, exchange="NMS",
+        industry="Software", sector="Technology",
+        source="yfinance", enriched_at="2026-02-20T00:00:00Z",
+    )]
+
+    svc = PeerDiscoveryService(cache_dir=tmp_path)
+
+    with patch.dict("os.environ", {"SIGMAK_PEER_YFINANCE_ENABLED": "true"}):
+        with patch("sigmak.adapters.yfinance_adapter.YFinanceAdapter.get_peers", return_value=expected):
+            result = svc.get_peers_via_yfinance("MSFT", n=5)
+
+    assert result == expected


### PR DESCRIPTION
Closes #96

- Add src/sigmak/adapters/ package with YFinanceAdapter and PeerRecord dataclass; resolves industry via yf.Ticker, pulls top companies via yf.Industry (defensively probed), bulk-enriches with yf.Tickers, applies progressive market-cap filter (0.10→0.05→0.02→0.0) with percentile fallback when target cap is None
- Cache bulk payloads to cache_dir/yfinance/ with configurable TTL
- All config via SIGMAK_PEER_YFINANCE_* env vars (disabled by default)
- Upsert side-effect writes PeerRecords to peers table via upsert_peer()
- Add get_peers_via_yfinance() wrapper on PeerDiscoveryService
- Add --yfinance flag to scripts/demo_peer_discovery.py
- 10 fully-mocked TDD tests; all passing

Canonical SEC/EDGAR peer discovery is unchanged.