### PR TITLE
feat(cli): yfinance peer selection as CLI default (Issue #110)

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -3150,3 +3150,28 @@ delegates to the full peer comparison logic.
   (without `--year`) must be updated.
 - Script function bodies must remain intact due to `importlib`-based dynamic loading
   in `test_generate_peer_comparison_misfiled.py`.
+
+---
+
+## Issue #110 — yfinance peer selection as CLI default (2026-03-03)
+
+### Summary
+Changed the `peers` subcommand so yfinance-based peer discovery is the default.
+Added `--sic-only` flag to opt back into the SIC/EDGAR selection path.
+`SIGMAK_PEER_YFINANCE_ENABLED` is now set to `true` at CLI startup unless
+the environment already provides a value.
+
+### Changes
+| File | Change |
+|---|---|
+| `tests/test_cli_peers.py` | Updated `test_peers_run_calls_run_peer_comparison` to include `use_sic_only`; added 3 new tests |
+| `src/sigmak/__main__.py` | Added `import os`; `os.environ.setdefault("SIGMAK_PEER_YFINANCE_ENABLED","true")` in `main()`; `--sic-only` flag on `peers` subparser |
+| `src/sigmak/cli/peers.py` | Added `use_sic_only: bool = False` param; forwarded to `run_peer_comparison` |
+| `src/sigmak/reports/peer_report.py` | Added `use_sic_only: bool = False` param; branches on it for peer candidate selection |
+
+### Test Results
+23 tests passing (3 new + 20 regression).
+
+### Behavior
+- `uv run sigmak --ticker AAPL peers --year 2024` → uses yfinance
+- `uv run sigmak --ticker AAPL peers --year 2024 --sic-only` → uses SIC/EDGAR

--- a/documentation/cli-scaffolding/110_PEER_SELECTION_WITH_YFINANCE.md
+++ b/documentation/cli-scaffolding/110_PEER_SELECTION_WITH_YFINANCE.md
@@ -1,0 +1,33 @@
+**Relates to:** #103, #106
+
+## Overview
+
+By default, `uv run sigmak --ticker AAPL peers --year 2024` should use yfinance-based peer selection (via `PeerDiscoveryService.get_peers_via_yfinance`). The old SIC/EDGAR-based selection should only be used when explicitly requested via a new `--sic-only` flag. This will allow demo_peer_discovery.py and related legacy scripts to be safely deleted with no loss of yfinance peer selection functionality.
+
+## Acceptance Criteria
+
+- [ ] At CLI startup, always set `SIGMAK_PEER_YFINANCE_ENABLED=true` unless it is already set in the environment.
+- [ ] Add `--sic-only` boolean flag (`action="store_true"`) to the `peers` subparser in `__main__.py`.
+- [ ] Propagate `use_sic_only` all the way to `run_peer_comparison()` in `reports/peer_report.py`.
+- [ ] In `run_peer_comparison()`, use yfinance-based peer selection by default (extracting `.ticker` from returned `PeerRecord` list). If `use_sic_only` is true, use SIC/EDGAR selection logic (`find_peers_for_ticker`).
+- [ ] CLI help/README updated to clearly document this behavior (yfinance default, SIC is opt-out).
+- [ ] All existing and new tests reflect this: default is yfinance, flag can switch to SIC logic.
+- [ ] Example: `uv run sigmak --ticker AAPL peers --year 2024` uses yfinance; `uv run sigmak --ticker AAPL peers --year 2024 --sic-only` uses SEC/EDGAR fallback
+
+## Tests
+
+- `test_peers_sic_only_flag_registered` — parses correctly, defaults to False, True when present
+- `test_run_peer_comparison_sic_only_calls_find_peers_for_ticker`
+- `test_run_peer_comparison_defaults_to_yfinance`
+- End-to-end and integration CLI tests
+
+## Files to Modify
+
+- `src/sigmak/__main__.py`
+- `src/sigmak/cli/peers.py`
+- `src/sigmak/reports/peer_report.py`
+- CLI test suite, README, and usage docs
+
+---
+
+Once done, `scripts/demo_peer_discovery.py` and any README references to it can be safely removed.

--- a/src/sigmak/__main__.py
+++ b/src/sigmak/__main__.py
@@ -12,6 +12,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 
@@ -84,6 +85,13 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="TICKER",
         help="Explicit peer tickers (overrides auto-discovery).",
     )
+    peers_parser.add_argument(
+        "--sic-only",
+        action="store_true",
+        dest="use_sic_only",
+        default=False,
+        help="Use SIC/EDGAR peer selection instead of yfinance (default).",
+    )
     subparsers.add_parser("download", help="Download SEC filings.")
     subparsers.add_parser("inspect", help="Inspect the local database.")
     subparsers.add_parser("render", help="Render a Markdown report to PDF.")
@@ -99,6 +107,8 @@ def main(argv: list[str] | None = None) -> None:
     argv:
         Argument list to parse. Defaults to sys.argv[1:] when None.
     """
+    os.environ.setdefault("SIGMAK_PEER_YFINANCE_ENABLED", "true")
+
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/src/sigmak/cli/peers.py
+++ b/src/sigmak/cli/peers.py
@@ -10,6 +10,7 @@ def run(
     max_peers: int,
     explicit_peers: List[str] | None,
     db_only: bool,
+    use_sic_only: bool = False,
     **_: object,
 ) -> None:
     """Delegate to ``sigmak.reports.peer_report.run_peer_comparison``."""
@@ -21,4 +22,5 @@ def run(
         max_peers=max_peers,
         explicit_peers=explicit_peers,
         db_only=db_only,
+        use_sic_only=use_sic_only,
     )

--- a/src/sigmak/reports/peer_report.py
+++ b/src/sigmak/reports/peer_report.py
@@ -609,6 +609,7 @@ def run_peer_comparison(
     max_peers: int,
     explicit_peers: List[str] | None,
     db_only: bool,
+    use_sic_only: bool = False,
     db_path: str = "./database/sec_filings.db",
     download_dir: str = "./data/filings",
 ) -> None:
@@ -623,6 +624,9 @@ def run_peer_comparison(
                  If provided, use these tickers as the peer list instead of
                  auto-discovery.
     db_only:     When True, skip LLM classification and use ChromaDB only.
+    use_sic_only:
+                 When True, use SIC/EDGAR peer selection instead of yfinance
+                 (the default).
     db_path:     Path to the SQLite filings database.
     download_dir:
                  Base directory where 10-K HTML files are stored.
@@ -659,8 +663,11 @@ def run_peer_comparison(
 
     if explicit_peers:
         candidates = [p.upper() for p in explicit_peers if p.upper() != target]
-    else:
+    elif use_sic_only:
         candidates = svc.find_peers_for_ticker(target, top_n=max(desired * 3, desired + 6))
+    else:
+        peer_records = svc.get_peers_via_yfinance(target, n=max(desired * 3, desired + 6))
+        candidates = [pr.ticker.upper() for pr in peer_records]
 
     for cand in candidates:
         if len(collected) >= desired:

--- a/tests/test_cli_peers.py
+++ b/tests/test_cli_peers.py
@@ -1,9 +1,10 @@
 """
-Tests for Issue 103: peers CLI subcommand wiring.
+Tests for Issue 103 / Issue 110: peers CLI subcommand wiring and yfinance peer selection.
 
 Each test verifies exactly one behavior (SRP).
 """
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 from sigmak.__main__ import main
 
@@ -13,13 +14,14 @@ def test_peers_run_calls_run_peer_comparison() -> None:
     with patch("sigmak.reports.peer_report.run_peer_comparison") as mock_fn:
         from sigmak.cli.peers import run
 
-        run(ticker="NVDA", year=2024, max_peers=6, explicit_peers=None, db_only=False)
+        run(ticker="NVDA", year=2024, max_peers=6, explicit_peers=None, db_only=False, use_sic_only=False)
         mock_fn.assert_called_once_with(
             ticker="NVDA",
             year=2024,
             max_peers=6,
             explicit_peers=None,
             db_only=False,
+            use_sic_only=False,
         )
 
 
@@ -49,3 +51,76 @@ def test_peers_db_only_flag_forwarded() -> None:
         mock_run.assert_called_once()
         call_kwargs = mock_run.call_args[1]
         assert call_kwargs["db_only"] is True
+
+
+def test_peers_sic_only_flag_registered() -> None:
+    """--sic-only is forwarded as use_sic_only=True; defaults to False when absent."""
+    with patch("sigmak.cli.peers.run") as mock_run:
+        main(["--ticker", "AAPL", "peers", "--year", "2024", "--sic-only"])
+        mock_run.assert_called_once()
+        assert mock_run.call_args[1]["use_sic_only"] is True
+
+    with patch("sigmak.cli.peers.run") as mock_run:
+        main(["--ticker", "AAPL", "peers", "--year", "2024"])
+        mock_run.assert_called_once()
+        assert mock_run.call_args[1]["use_sic_only"] is False
+
+
+def test_run_peer_comparison_defaults_to_yfinance() -> None:
+    """run_peer_comparison calls get_peers_via_yfinance when use_sic_only=False."""
+    from sigmak.reports.peer_report import run_peer_comparison
+
+    mock_result = MagicMock()
+    mock_result.ticker = "NVDA"
+    mock_result.filing_year = 2024
+    mock_result.risks = []
+    mock_result.metadata = {}
+
+    with (
+        patch("sigmak.reports.peer_report.TenKDownloader"),
+        patch("sigmak.reports.peer_report.IntegrationPipeline"),
+        patch("sigmak.reports.peer_report.PeerDiscoveryService") as mock_svc_cls,
+        patch("sigmak.reports.peer_report.ensure_filing", return_value=MagicMock()),
+        patch("sigmak.reports.peer_report.load_or_analyze_with_cache", return_value=mock_result),
+        patch("sigmak.reports.peer_report.generate_markdown_report"),
+    ):
+        mock_svc = mock_svc_cls.return_value
+        mock_svc.get_peers_via_yfinance.return_value = []
+
+        run_peer_comparison(
+            ticker="NVDA", year=2024, max_peers=6, explicit_peers=None,
+            db_only=False, use_sic_only=False,
+        )
+
+        mock_svc.get_peers_via_yfinance.assert_called_once()
+        mock_svc.find_peers_for_ticker.assert_not_called()
+
+
+def test_run_peer_comparison_sic_only_calls_find_peers_for_ticker() -> None:
+    """run_peer_comparison calls find_peers_for_ticker when use_sic_only=True."""
+    from sigmak.reports.peer_report import run_peer_comparison
+
+    mock_result = MagicMock()
+    mock_result.ticker = "NVDA"
+    mock_result.filing_year = 2024
+    mock_result.risks = []
+    mock_result.metadata = {}
+
+    with (
+        patch("sigmak.reports.peer_report.TenKDownloader"),
+        patch("sigmak.reports.peer_report.IntegrationPipeline"),
+        patch("sigmak.reports.peer_report.PeerDiscoveryService") as mock_svc_cls,
+        patch("sigmak.reports.peer_report.ensure_filing", return_value=MagicMock()),
+        patch("sigmak.reports.peer_report.load_or_analyze_with_cache", return_value=mock_result),
+        patch("sigmak.reports.peer_report.generate_markdown_report"),
+    ):
+        mock_svc = mock_svc_cls.return_value
+        mock_svc.find_peers_for_ticker.return_value = []
+
+        run_peer_comparison(
+            ticker="NVDA", year=2024, max_peers=6, explicit_peers=None,
+            db_only=False, use_sic_only=True,
+        )
+
+        mock_svc.find_peers_for_ticker.assert_called_once()
+        mock_svc.get_peers_via_yfinance.assert_not_called()


### PR DESCRIPTION
- Set SIGMAK_PEER_YFINANCE_ENABLED=true at CLI startup (setdefault)
- Add --sic-only flag to peers subparser; propagate use_sic_only through cli/peers.py -> run_peer_comparison()
- run_peer_comparison() defaults to get_peers_via_yfinance(); uses find_peers_for_ticker() only when use_sic_only=True
- 23 tests passing (3 new + 20 regression)