### PR TITLE
feat(cli): wire inspect and render subcommands (issue #105)

### DIFF
--- a/documentation/cli-scaffolding/105_WIRE_INSPECT_AND_RENDER.md
+++ b/documentation/cli-scaffolding/105_WIRE_INSPECT_AND_RENDER.md
@@ -1,0 +1,86 @@
+**Title:** `CLI: implement inspect and render subcommands`
+
+**Body:**
+
+## Overview
+
+Wire the two remaining utility subcommands:
+- `uv run sigmak --ticker AAPL inspect` — delegates to `scripts/inspect_chroma.py` logic
+- `uv run sigmak --ticker AAPL render --input output/AAPL_YoY.md` — delegates to 
+  `scripts/md_to_pdf.py` logic
+
+Note: `render` does not conceptually need `--ticker`, but it stays consistent with 
+the global required flag. The `--ticker` value can be ignored in the render 
+implementation.
+
+---
+
+## Acceptance Criteria
+
+### inspect
+- [ ] `src/sigmak/cli/inspect_db.py` replaces stub with:
+      ```python
+      def run(ticker: str, chroma_dir: str = "./database", 
+              max_sample: int = 5) -> None:
+      ```
+      which calls the inspection logic from `scripts/inspect_chroma.py`
+- [ ] `__main__.py` `inspect` subcommand gains optional args:
+      - `--chroma-dir PATH` (default `./database`)
+      - `--max-sample INT` (default 5)
+- [ ] `scripts/inspect_chroma.py` `main()` delegates to `cli.inspect_db.run()`
+
+### render
+- [ ] `src/sigmak/cli/render.py` replaces stub with:
+      ```python
+      def run(input_path: str, output_path: str | None = None, 
+              css_path: str = "styles/report.css", 
+              title: str | None = None) -> None:
+      ```
+      which calls `convert_md_to_pdf()` from `scripts/md_to_pdf.py` (or extract 
+      that function to `src/sigmak/reports/pdf_renderer.py`)
+- [ ] `__main__.py` `render` subcommand:
+      - `--input PATH` (required)
+      - `--output PATH` (optional)
+      - `--css PATH` (default `styles/report.css`)
+      - `--title STR` (optional)
+- [ ] `scripts/md_to_pdf.py` `main()` delegates to `cli.render.run()`
+- [ ] `render` gracefully exits with an informative error message if `weasyprint` 
+      is not installed (it is an optional dependency)
+- [ ] All existing tests still pass
+
+---
+
+## Tests (write FIRST)
+
+File: `tests/test_cli_inspect.py`
+- `test_inspect_main_dispatch_calls_cli_run` — mock `sigmak.cli.inspect_db.run`; 
+  call `main(['--ticker', 'AAPL', 'inspect'])`; assert mock called with 
+  `ticker='AAPL'`
+- `test_inspect_chroma_dir_forwarded` — mock `sigmak.cli.inspect_db.run`; call 
+  with `--chroma-dir ./mydb`; assert `chroma_dir='./mydb'` forwarded
+
+File: `tests/test_cli_render.py`
+- `test_render_main_dispatch_calls_cli_run` — mock `sigmak.cli.render.run`; call 
+  `main(['--ticker', 'AAPL', 'render', '--input', 'output/test.md'])`; assert 
+  mock called with `input_path='output/test.md'`
+- `test_render_missing_weasyprint_exits_gracefully` — mock `weasyprint` as 
+  unavailable (ImportError); call `cli.render.run(input_path='x.md')`; assert 
+  SystemExit or a clean error message is printed (no unhandled traceback)
+- `test_render_output_path_forwarded` — mock run internals; verify `--output` 
+  arg forwarded correctly
+
+---
+
+## Files to Create / Modify
+
+- `src/sigmak/cli/inspect_db.py` (update stub)
+- `src/sigmak/cli/render.py` (update stub)
+- `src/sigmak/reports/pdf_renderer.py` (optional extraction of `convert_md_to_pdf`)
+- `scripts/inspect_chroma.py` (update main() to delegate)
+- `scripts/md_to_pdf.py` (update main() to delegate)
+- `tests/test_cli_inspect.py` (new)
+- `tests/test_cli_render.py` (new)
+
+---
+
+## Journal Entry (add to JOURNAL.md when complete)

--- a/scripts/inspect_chroma.py
+++ b/scripts/inspect_chroma.py
@@ -138,35 +138,11 @@ def inspect_sqlite_schema(sqlite_path: str) -> Dict[str, Any]:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
-    """Orchestrate inspection and print JSON summary to stdout."""
+    """Delegate to ``sigmak.cli.inspect_db.run``."""
     args = parse_args(argv)
-    try:
-        client = create_client(args.dir)
-    except Exception as exc:
-        print("Failed to create chromadb client:", exc, file=sys.stderr)
-        return 2
+    from sigmak.cli.inspect_db import run
 
-    available = list_collection_names(client)
-    requested: List[str]
-    if args.collections:
-        requested = [c.strip() for c in args.collections.split(",") if c.strip()]
-    else:
-        requested = available
-
-    result: Dict[str, Any] = {"persist_dir": args.dir, "collections": {}, "available_collections": available}
-    for name in requested:
-        if name not in available:
-            result["collections"][name] = {"error": "collection not found"}
-            continue
-        sample = sample_collection(client, name, limit=args.max_sample, show_docs=args.show_docs, show_meta=args.show_metadata)
-        result["collections"][name] = sample
-
-    if args.inspect_sqlite:
-        sqlite_path = f"{args.dir.rstrip('/')}/chroma.sqlite3"
-        result["sqlite"] = inspect_sqlite_schema(sqlite_path)
-
-    # Pretty-print JSON to stdout so the caller can redirect or parse
-    print(json.dumps(result, indent=2, ensure_ascii=False))
+    run(ticker="", chroma_dir=args.dir, max_sample=args.max_sample)
     return 0
 
 

--- a/scripts/md_to_pdf.py
+++ b/scripts/md_to_pdf.py
@@ -25,73 +25,24 @@ Dependencies:
 from pathlib import Path
 import argparse
 import sys
-from markdown import markdown
-from jinja2 import Template
-from weasyprint import HTML, CSS
 
 
-# Simple HTML template wrapper for the Markdown content
-HTML_TEMPLATE = """<!doctype html>
-<html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>{{ title }}</title>
-</head>
-<body>
-{{ content }}
-</body>
-</html>
-"""
-
-
+# HTML_TEMPLATE and convert_md_to_pdf now live in sigmak.reports.pdf_renderer.
+# This re-export preserves backward compatibility for any callers.
 def convert_md_to_pdf(
     md_path: Path,
     out_pdf: Path,
     css_path: Path,
-    title: str | None = None
+    title: str | None = None,
 ) -> None:
-    """
-    Convert Markdown file to styled PDF.
-    
-    Args:
-        md_path: Input Markdown file
-        out_pdf: Output PDF file
-        css_path: CSS stylesheet for PDF styling
-        title: Document title (defaults to filename stem)
-    
-    The conversion process:
-        1. Read Markdown text
-        2. Convert to HTML using Python-Markdown
-        3. Wrap in minimal HTML template
-        4. Render to PDF with CSS styling via WeasyPrint
-    """
-    # Read Markdown source
-    md_text = md_path.read_text(encoding="utf-8")
-    
-    # Convert Markdown → HTML
-    # Extensions: fenced_code (```) | tables | toc (auto table of contents)
-    html_body = markdown(
-        md_text,
-        extensions=["fenced_code", "tables", "toc"]
-    )
-    
-    # Wrap in minimal HTML template
-    template = Template(HTML_TEMPLATE)
-    html = template.render(
-        title=title or md_path.stem,
-        content=html_body
-    )
-    
-    # Render HTML → PDF with styling
-    # base_url allows relative image paths in Markdown to resolve correctly
-    HTML(string=html, base_url=str(md_path.parent)).write_pdf(
-        str(out_pdf),
-        stylesheets=[CSS(filename=str(css_path))]
-    )
+    """Thin wrapper — delegates to ``sigmak.reports.pdf_renderer.convert_md_to_pdf``."""
+    from sigmak.reports.pdf_renderer import convert_md_to_pdf as _impl
+
+    _impl(md_path, out_pdf, css_path, title)
 
 
 def main() -> None:
-    """CLI entry point."""
+    """Delegate to ``sigmak.cli.render.run``."""
     parser = argparse.ArgumentParser(
         description="Convert Markdown report to styled PDF",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -128,28 +79,15 @@ Examples:
     )
     
     args = parser.parse_args()
-    
-    # Validate input file exists
-    if not args.md.exists():
-        print(f"Error: Input file not found: {args.md}", file=sys.stderr)
-        sys.exit(1)
-    
-    # Validate CSS file exists
-    if not args.css.exists():
-        print(f"Error: CSS file not found: {args.css}", file=sys.stderr)
-        print(f"Hint: Create a default CSS at styles/report.css", file=sys.stderr)
-        sys.exit(1)
-    
-    # Default output path
-    out_pdf = args.out or args.md.with_suffix(".pdf")
-    
-    # Convert
-    try:
-        convert_md_to_pdf(args.md, out_pdf, args.css, args.title)
-        print(f"✓ Created PDF: {out_pdf}")
-    except Exception as e:
-        print(f"Error during conversion: {e}", file=sys.stderr)
-        sys.exit(1)
+
+    from sigmak.cli.render import run
+
+    run(
+        input_path=str(args.md),
+        output_path=str(args.out) if args.out else None,
+        css_path=str(args.css),
+        title=args.title,
+    )
 
 
 if __name__ == "__main__":

--- a/src/sigmak/__main__.py
+++ b/src/sigmak/__main__.py
@@ -117,8 +117,50 @@ def build_parser() -> argparse.ArgumentParser:
         metavar="N",
         help="Maximum number of peers to download when --include-peers is set (default: 6).",
     )
-    subparsers.add_parser("inspect", help="Inspect the local database.")
-    subparsers.add_parser("render", help="Render a Markdown report to PDF.")
+    inspect_parser = subparsers.add_parser("inspect", help="Inspect the local database.")
+    inspect_parser.add_argument(
+        "--chroma-dir",
+        default="./database",
+        dest="chroma_dir",
+        metavar="PATH",
+        help="ChromaDB persistence directory (default: ./database).",
+    )
+    inspect_parser.add_argument(
+        "--max-sample",
+        type=int,
+        default=5,
+        dest="max_sample",
+        metavar="N",
+        help="Maximum sample rows per collection (default: 5).",
+    )
+
+    render_parser = subparsers.add_parser("render", help="Render a Markdown report to PDF.")
+    render_parser.add_argument(
+        "--input",
+        required=True,
+        dest="input_path",
+        metavar="PATH",
+        help="Input Markdown file to convert.",
+    )
+    render_parser.add_argument(
+        "--output",
+        default=None,
+        dest="output_path",
+        metavar="PATH",
+        help="Output PDF path (default: same stem as input).",
+    )
+    render_parser.add_argument(
+        "--css",
+        default="styles/report.css",
+        dest="css_path",
+        metavar="PATH",
+        help="CSS stylesheet for PDF styling (default: styles/report.css).",
+    )
+    render_parser.add_argument(
+        "--title",
+        default=None,
+        help="Document title (default: input filename stem).",
+    )
 
     return parser
 

--- a/src/sigmak/cli/inspect_db.py
+++ b/src/sigmak/cli/inspect_db.py
@@ -1,5 +1,118 @@
-"""CLI stub for the `inspect` subcommand."""
+"""CLI handler for the `inspect` subcommand.
+
+Prints a JSON summary of the ChromaDB persistence directory to stdout.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+from typing import Any, Dict, List
 
 
-def run(**kwargs: object) -> None:
-    print("not yet implemented")
+def _import_chromadb() -> Any:
+    """Import chromadb and return the module."""
+    try:
+        import chromadb  # type: ignore[import-untyped]
+
+        return chromadb
+    except Exception as exc:
+        raise ImportError("chromadb is not installed or failed to import") from exc
+
+
+def _create_client(persist_dir: str) -> Any:
+    """Return a ChromaDB client pointing at *persist_dir*."""
+    chromadb = _import_chromadb()
+    # Modern API (chromadb >= 0.4)
+    try:
+        return chromadb.PersistentClient(path=persist_dir)
+    except Exception:
+        pass
+    # Older Settings-based API
+    try:
+        from chromadb.config import Settings  # type: ignore[import-untyped]
+
+        return chromadb.Client(
+            Settings(chroma_db_impl="duckdb+parquet", persist_directory=persist_dir)
+        )
+    except Exception:
+        pass
+    try:
+        return chromadb.Client(persist_directory=persist_dir)
+    except Exception as exc:
+        raise RuntimeError("Failed to create chromadb client") from exc
+
+
+def _list_collection_names(client: Any) -> List[str]:
+    """Return the names of all collections in *client*."""
+    try:
+        cols = client.list_collections()
+    except Exception:
+        try:
+            cols = client.get_collections()
+        except Exception:
+            return []
+    names: List[str] = []
+    for c in cols:
+        if isinstance(c, dict):
+            name: str | None = c.get("name") or c.get("id")
+        else:
+            name = getattr(c, "name", None) or getattr(c, "id", None)
+        if name:
+            names.append(name)
+    return names
+
+
+def _sample_collection(client: Any, name: str, limit: int = 5) -> Dict[str, Any]:
+    """Return a small sample of document ids from *name*."""
+    out: Dict[str, Any] = {"name": name, "count": 0, "ids": []}
+    try:
+        col = client.get_collection(name=name)
+        try:
+            sample = col.get(offset=0, limit=limit, include=["ids"])
+        except Exception:
+            sample = {"ids": []}
+        ids = sample.get("ids", [])
+        out["count"] = len(ids)
+        out["ids"] = ids
+    except Exception:
+        out["error"] = traceback.format_exc()
+    return out
+
+
+def run(
+    ticker: str,
+    chroma_dir: str = "./database",
+    max_sample: int = 5,
+    **_: object,
+) -> None:
+    """Inspect the ChromaDB at *chroma_dir* and print a JSON summary.
+
+    Parameters
+    ----------
+    ticker:
+        Target ticker symbol (accepted for CLI consistency; unused here).
+    chroma_dir:
+        Path to the ChromaDB persistence directory.
+    max_sample:
+        Maximum number of sample rows displayed per collection.
+    """
+    try:
+        client = _create_client(chroma_dir)
+    except Exception as exc:
+        print(
+            f"Error: Failed to connect to ChromaDB at '{chroma_dir}': {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    available = _list_collection_names(client)
+    result: Dict[str, Any] = {
+        "persist_dir": chroma_dir,
+        "available_collections": available,
+        "collections": {},
+    }
+    for name in available:
+        result["collections"][name] = _sample_collection(client, name, limit=max_sample)
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))

--- a/src/sigmak/cli/render.py
+++ b/src/sigmak/cli/render.py
@@ -1,5 +1,61 @@
-"""CLI stub for the `render` subcommand."""
+"""CLI handler for the `render` subcommand.
+
+Converts a Markdown report to a styled PDF via WeasyPrint.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
 
 
-def run(**kwargs: object) -> None:
-    print("not yet implemented")
+def run(
+    input_path: str,
+    output_path: str | None = None,
+    css_path: str = "styles/report.css",
+    title: str | None = None,
+    **_: object,
+) -> None:
+    """Render *input_path* (Markdown) to a PDF.
+
+    Parameters
+    ----------
+    input_path:
+        Path to the input ``.md`` file.
+    output_path:
+        Destination ``.pdf`` path.  Defaults to *input_path* with ``.pdf``
+        extension.
+    css_path:
+        Path to the CSS stylesheet (default: ``styles/report.css``).
+    title:
+        Document title embedded in the PDF.  Defaults to the input filename
+        stem.
+    """
+    md = Path(input_path)
+    if not md.exists():
+        print(f"Error: Input file not found: {md}", file=sys.stderr)
+        sys.exit(1)
+
+    css = Path(css_path)
+    if not css.exists():
+        print(f"Error: CSS file not found: {css}", file=sys.stderr)
+        print("Hint: create a stylesheet at styles/report.css", file=sys.stderr)
+        sys.exit(1)
+
+    out_pdf = Path(output_path) if output_path else md.with_suffix(".pdf")
+
+    from sigmak.reports.pdf_renderer import convert_md_to_pdf
+
+    try:
+        convert_md_to_pdf(md, out_pdf, css, title)
+    except ImportError:
+        print(
+            "Error: PDF rendering requires the 'pdf' optional dependencies.\n"
+            "Install them with:  uv pip install sigmak[pdf]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except Exception as exc:
+        print(f"Error during PDF conversion: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Created PDF: {out_pdf}")

--- a/src/sigmak/reports/pdf_renderer.py
+++ b/src/sigmak/reports/pdf_renderer.py
@@ -1,0 +1,59 @@
+"""PDF rendering utilities for SigmaK reports.
+
+``weasyprint``, ``markdown``, and ``jinja2`` are optional dependencies
+(extras group ``pdf``).  All three are imported lazily inside
+``convert_md_to_pdf`` so this module can be imported without them installed.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+_HTML_TEMPLATE = """<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>{{ title }}</title>
+</head>
+<body>
+{{ content }}
+</body>
+</html>
+"""
+
+
+def convert_md_to_pdf(
+    md_path: Path,
+    out_pdf: Path,
+    css_path: Path,
+    title: str | None = None,
+) -> None:
+    """Convert a Markdown file to a styled PDF.
+
+    Parameters
+    ----------
+    md_path:
+        Input Markdown file.
+    out_pdf:
+        Output PDF file.
+    css_path:
+        CSS stylesheet for PDF styling.
+    title:
+        Document title; defaults to the input filename stem.
+
+    Raises
+    ------
+    ImportError
+        If ``weasyprint``, ``markdown``, or ``jinja2`` are not installed.
+    """
+    from markdown import markdown  # type: ignore[import-untyped]
+    from jinja2 import Template  # type: ignore[import-untyped]
+    from weasyprint import HTML, CSS  # type: ignore[import-untyped]
+
+    md_text = md_path.read_text(encoding="utf-8")
+    html_body = markdown(md_text, extensions=["fenced_code", "tables", "toc"])
+    template = Template(_HTML_TEMPLATE)
+    html = template.render(title=title or md_path.stem, content=html_body)
+    HTML(string=html, base_url=str(md_path.parent)).write_pdf(
+        str(out_pdf),
+        stylesheets=[CSS(filename=str(css_path))],
+    )

--- a/tests/test_cli_inspect.py
+++ b/tests/test_cli_inspect.py
@@ -1,0 +1,31 @@
+"""Tests for the `inspect` subcommand CLI wiring (Issue 105).
+
+Each test verifies exactly one behaviour (SRP).
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from sigmak.__main__ import main
+
+
+def test_inspect_main_dispatch_calls_cli_run() -> None:
+    """main() dispatches to cli.inspect_db.run with ticker forwarded."""
+    with patch("sigmak.cli.inspect_db.run") as mock_run:
+        main(["--ticker", "AAPL", "inspect"])
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args[1] if mock_run.call_args[1] else mock_run.call_args[0][0]
+        # ticker is passed through **kwargs from argparse namespace
+        call_kwargs = mock_run.call_args.kwargs if mock_run.call_args.kwargs else {}
+        # argparse dispatches via run(**vars(args)), so positional or keyword
+        all_args = {**dict(zip(["ticker"], mock_run.call_args.args)), **call_kwargs}
+        assert all_args.get("ticker") == "AAPL"
+
+
+def test_inspect_chroma_dir_forwarded() -> None:
+    """--chroma-dir value is forwarded to cli.inspect_db.run as chroma_dir."""
+    with patch("sigmak.cli.inspect_db.run") as mock_run:
+        main(["--ticker", "AAPL", "inspect", "--chroma-dir", "./mydb"])
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args.kwargs if mock_run.call_args.kwargs else {}
+        assert call_kwargs.get("chroma_dir") == "./mydb"

--- a/tests/test_cli_render.py
+++ b/tests/test_cli_render.py
@@ -1,0 +1,58 @@
+"""Tests for the `render` subcommand CLI wiring (Issue 105).
+
+Each test verifies exactly one behaviour (SRP).
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import patch
+
+from sigmak.__main__ import main
+
+
+def test_render_main_dispatch_calls_cli_run() -> None:
+    """main() dispatches to cli.render.run with input_path forwarded."""
+    with patch("sigmak.cli.render.run") as mock_run:
+        main(["--ticker", "AAPL", "render", "--input", "output/test.md"])
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args.kwargs if mock_run.call_args.kwargs else {}
+        assert call_kwargs.get("input_path") == "output/test.md"
+
+
+def test_render_missing_weasyprint_exits_gracefully(tmp_path: "Path") -> None:  # type: ignore[name-defined]
+    """cli.render.run exits with SystemExit(1) when weasyprint is unavailable."""
+    from pathlib import Path
+
+    md = tmp_path / "x.md"
+    md.write_text("# test")
+    css = tmp_path / "report.css"
+    css.write_text("body {}")
+
+    with patch(
+        "sigmak.reports.pdf_renderer.convert_md_to_pdf",
+        side_effect=ImportError("No module named 'weasyprint'"),
+    ):
+        from sigmak.cli.render import run
+
+        with pytest.raises(SystemExit) as exc_info:
+            run(input_path=str(md), css_path=str(css))
+        assert exc_info.value.code == 1
+
+
+def test_render_output_path_forwarded() -> None:
+    """--output value is forwarded to cli.render.run as output_path."""
+    with patch("sigmak.cli.render.run") as mock_run:
+        main(
+            [
+                "--ticker",
+                "AAPL",
+                "render",
+                "--input",
+                "output/test.md",
+                "--output",
+                "output/test.pdf",
+            ]
+        )
+        mock_run.assert_called_once()
+        call_kwargs = mock_run.call_args.kwargs if mock_run.call_args.kwargs else {}
+        assert call_kwargs.get("output_path") == "output/test.pdf"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -82,9 +82,9 @@ def test_inspect_subcommand_registered() -> None:
 
 
 def test_render_subcommand_registered() -> None:
-    """parse_args(['--ticker', 'AAPL', 'render']) sets args.command == 'render'."""
+    """parse_args(['--ticker', 'AAPL', 'render', '--input', 'x.md']) sets args.command == 'render'."""
     parser = build_parser()
-    args = parser.parse_args(["--ticker", "AAPL", "render"])
+    args = parser.parse_args(["--ticker", "AAPL", "render", "--input", "x.md"])
     assert args.command == "render"
 
 


### PR DESCRIPTION
- Extract convert_md_to_pdf to src/sigmak/reports/pdf_renderer.py
- Implement cli/inspect_db.run() with ChromaDB inspection logic
- Implement cli/render.run() with weasyprint ImportError guard
- Add --chroma-dir, --max-sample args to inspect subcommand
- Add --input (required), --output, --css, --title args to render subcommand
- Delegate scripts/inspect_chroma.py main() to cli.inspect_db.run()
- Delegate scripts/md_to_pdf.py main() to cli.render.run()
- Add tests/test_cli_inspect.py (2 tests)
- Add tests/test_cli_render.py (3 tests)
- Fix test_main.py: supply required --input to render subcommand test